### PR TITLE
Discord links have been removed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,4 +144,4 @@ As a PR created you are responsible to:
 
 Once your pull request is merged, you are an official Percona Community Contributor. Welcome to the community!
 
-We're looking forward to your contributions and hope to hear from you soon on our [Forums](https://forums.percona.com) and [Discord](https://per.co.na/discord).
+We're looking forward to your contributions and hope to hear from you soon on our [Forums](https://forums.percona.com).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We encourage contributions and are always looking for new members that are as de
 
 If you’re looking for information about how you can contribute, we have [contribution guidelines](CONTRIBUTING.md) across all our repositories in `CONTRIBUTING.md` files. Some of them may just link to the main project’s repository’s contribution guidelines.
 
-We're looking forward to your contributions and hope to hear from you soon on our [Forums](https://forums.percona.com) and [Discord](https://per.co.na/discord).
+We're looking forward to your contributions and hope to hear from you soon on our [Forums](https://forums.percona.com).
 
 ## Submitting Bug Reports
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -14,7 +14,7 @@ processes.
 ## Process
 
 1. Draft a proposal under `docs/proposals`. Refer to the [proposal template](/docs/proposals/template.md).
-2. Discuss the proposal with other contributors opening new issues and/or joining [Discord](https://per.co.na/discord). 
+2. Discuss the proposal with other contributors opening new issues. 
 3. If the proposal is approved, submit a Pull Request.
    1. create a new directory in the format `NNN-Enhancement-Title`
    2. add your proposal based on the template and additional files to the new directory


### PR DESCRIPTION
The Community Team is closing the Discord channel and for this reason I have removed the links to the channel.