### PR TITLE
Use higher lever controller-runtime Watches function

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=dbaas-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.29.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -69,8 +69,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-05-09T10:03:00Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.28.0
+    createdAt: "2023-06-14T11:00:24Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: dbaas-operator.v0.1.15
   namespace: placeholder

--- a/bundle/manifests/dbaas.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/dbaas.percona.com_databaseclusters.yaml
@@ -303,7 +303,8 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   schedule:
@@ -1689,7 +1690,7 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                         runtimeClassName:
@@ -1798,7 +1799,7 @@ spec:
                                     be the minimum value between the SizeLimit specified
                                     here and the sum of memory limits of all containers
                                     in a pod. The default is nil which means that
-                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
@@ -1984,8 +1985,8 @@ spec:
                                         amount of compute resources required. If Requests
                                         is omitted for a container, it defaults to
                                         Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        to an implementation-defined value. Requests
+                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       type: object
                                   type: object
                                 selector:
@@ -2066,6 +2067,81 @@ spec:
                   cluster. A database starts in cluster mode if clusterSize >= 3.
                 format: int32
                 type: integer
+              dataSource:
+                description: DataSource defines a data source for a new cluster
+                properties:
+                  azure:
+                    description: BackupStorageProviderSpec represents set of settings
+                      to configure cloud provider.
+                    properties:
+                      bucket:
+                        type: string
+                      containerName:
+                        description: A container name is a valid DNS name that conforms
+                          to the Azure naming rules.
+                        type: string
+                      credentialsSecret:
+                        type: string
+                      endpointUrl:
+                        type: string
+                      prefix:
+                        type: string
+                      region:
+                        type: string
+                      storageClass:
+                        description: STANDARD, NEARLINE, COLDLINE, ARCHIVE for GCP
+                          Hot (Frequently accessed or modified data), Cool (Infrequently
+                          accessed or modified data), Archive (Rarely accessed or
+                          modified data) for Azure.
+                        type: string
+                    required:
+                    - credentialsSecret
+                    type: object
+                  destination:
+                    type: string
+                  image:
+                    type: string
+                  s3:
+                    description: BackupStorageProviderSpec represents set of settings
+                      to configure cloud provider.
+                    properties:
+                      bucket:
+                        type: string
+                      containerName:
+                        description: A container name is a valid DNS name that conforms
+                          to the Azure naming rules.
+                        type: string
+                      credentialsSecret:
+                        type: string
+                      endpointUrl:
+                        type: string
+                      prefix:
+                        type: string
+                      region:
+                        type: string
+                      storageClass:
+                        description: STANDARD, NEARLINE, COLDLINE, ARCHIVE for GCP
+                          Hot (Frequently accessed or modified data), Cool (Infrequently
+                          accessed or modified data), Archive (Rarely accessed or
+                          modified data) for Azure.
+                        type: string
+                    required:
+                    - credentialsSecret
+                    type: object
+                  sslInternalSecretName:
+                    type: string
+                  sslSecretName:
+                    type: string
+                  storage_type:
+                    description: BackupStorageType represents backup storage type.
+                    type: string
+                  storageName:
+                    type: string
+                  vaultSecretName:
+                    type: string
+                required:
+                - storage_type
+                type: object
               databaseConfig:
                 description: DatabaseConfig contains a config settings for the specified
                   database.
@@ -2169,17 +2245,18 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   size:
                     format: int32
                     type: integer
                   trafficPolicy:
-                    description: ServiceExternalTrafficPolicyType describes how nodes
+                    description: ServiceExternalTrafficPolicy describes how nodes
                       distribute service traffic they receive on one of the Service's
                       "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer
-                      IPs).
+                      IPs.
                     type: string
                   type:
                     description: LoadBalancerType contains supported loadbalancers.
@@ -2427,7 +2504,8 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   runtimeClassName:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: dbaas-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.29.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/dbaas.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/dbaas.percona.com_databaseclusters.yaml
@@ -304,7 +304,8 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   schedule:
@@ -1690,7 +1691,7 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                         runtimeClassName:
@@ -1799,7 +1800,7 @@ spec:
                                     be the minimum value between the SizeLimit specified
                                     here and the sum of memory limits of all containers
                                     in a pod. The default is nil which means that
-                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
@@ -1985,8 +1986,8 @@ spec:
                                         amount of compute resources required. If Requests
                                         is omitted for a container, it defaults to
                                         Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        to an implementation-defined value. Requests
+                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       type: object
                                   type: object
                                 selector:
@@ -2245,17 +2246,18 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   size:
                     format: int32
                     type: integer
                   trafficPolicy:
-                    description: ServiceExternalTrafficPolicyType describes how nodes
+                    description: ServiceExternalTrafficPolicy describes how nodes
                       distribute service traffic they receive on one of the Service's
                       "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer
-                      IPs).
+                      IPs.
                     type: string
                   type:
                     description: LoadBalancerType contains supported loadbalancers.
@@ -2503,7 +2505,8 @@ spec:
                         description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
                   runtimeClassName:

--- a/controllers/databaseengine_controller.go
+++ b/controllers/databaseengine_controller.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	dbaasv1 "github.com/percona/dbaas-operator/api/v1"
 )
@@ -154,6 +153,6 @@ func (r *DatabaseEngineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&dbaasv1.DatabaseEngine{}).
-		WatchesRawSource(source.Kind(mgr.GetCache(), &appsv1.Deployment{}), &handler.EnqueueRequestForObject{}).
+		Watches(&appsv1.Deployment{}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }


### PR DESCRIPTION
According to the controller-runtime/pkg/builder doc, the WatchesRawSource method is only exposed for more advanced use cases, most users should use higher level functions.
In our case, the Watches method does exactly what we need so we'll use that.