### PR TITLE
Update linter config

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,15 +51,9 @@ jobs:
         run: bin/go-sumtype ./...
 
       - name: Run linters
-        uses: reviewdog/action-golangci-lint@v2
-        with:
-          github_token: ${{ secrets.ROBOT_TOKEN || secrets.GITHUB_TOKEN }}
-          go_version: ${{ env.GO_VERSION }}
-          reporter: github-pr-review
-          fail_on_error: true
-          cache: false
-          golangci_lint_flags: "-c=.golangci.yml"
-          golangci_lint_version: v1.51.1 # Version should match specified in Makefile
+        run: |
+          # use GITHUB_TOKEN because only it has access to GitHub Checks API
+          bin/golangci-lint run --out-format=line-number | env REVIEWDOG_GITHUB_API_TOKEN=${{ secrets.GITHUB_TOKEN }} bin/reviewdog -f=golangci-lint -reporter=github-pr-review -filter-mode=nofilter -fail-on-error=true
 
       - name: Run debug commands on failure
         if: ${{ failure() }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,17 +7,17 @@ linters-settings:
 
 
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages:
-      # use "github.com/pkg/errors" instead
-      - errors
-      # use "github.com/golang/protobuf/proto" instead
-      - github.com/gogo/protobuf/proto
-      # use only forked parser
-      - github.com/percona/go-mysql/log/slow
-      # use "gopkg.in/yaml.v3" instead
-      - gopkg.in/yaml.v2
+    rules:
+      main:
+        deny:
+          - pkg: "errors"
+            desc: "use 'github.com/pkg/errors' instead"
+          - pkg: "github.com/gogo/protobuf/proto"
+            desc: "use 'github.com/golang/protobuf/proto' instead"
+          - pkg: "github.com/percona/go-mysql/log/slow"
+            desc: "use only forked parser"
+          - pkg: "gopkg.in/yaml.v2"
+            desc: "use 'gopkg.in/yaml.v3' instead"
 
   gci:
     sections:

--- a/controllers/version.go
+++ b/controllers/version.go
@@ -95,7 +95,7 @@ func (v *Version) PSMDBBackupImage() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer resp.Body.Close() //nolint:errcheck,gosec
+		defer resp.Body.Close() //nolint:errcheck
 		var vr VersionResponse
 		if err := json.NewDecoder(resp.Body).Decode(&vr); err != nil {
 			return "", err


### PR DESCRIPTION
Locally there are tons of linter error appear by using `make check` but the CI passes. It turned out we use different versions of golangci-lint in CI and locally. Since it's easy to miss this versions misalignment in the future, the CI is updated to use the same binary of golangci-lint. 